### PR TITLE
Add install instructions comment to sentiment hub

### DIFF
--- a/sentiment_hub.py
+++ b/sentiment_hub.py
@@ -1,3 +1,12 @@
+"""
+Sentiment Hub - aggregated sentiment scoring service.
+
+Installation requirements:
+    pip install fastapi uvicorn[standard] requests feedparser python-dotenv sqlalchemy transformers torch praw
+
+Run with: python sentiment_hub.py
+"""
+
 import os, re, time, math, json, asyncio, logging, hashlib
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional


### PR DESCRIPTION
## Summary
- add requirements comment at top of `sentiment_hub.py`

## Testing
- `python -m py_compile sentiment_hub.py`
- `python sentiment_hub.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests feedparser fastapi pydantic python-dotenv --quiet` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_6896495e76b083318617bfe29ef242eb